### PR TITLE
feat: Use custom plist path if xcode_archive_path is null

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
@@ -38,10 +38,16 @@ module Fastlane
       end
 
       def get_ios_app_id_from_archive_plist(archive_path, plist_path)
-        app_path = parse_plist("#{archive_path}/Info.plist")["ApplicationProperties"]["ApplicationPath"]
-        UI.shell_error!("can't extract application path from Info.plist at #{archive_path}") if app_path.empty?
-        identifier = parse_plist("#{archive_path}/Products/#{app_path}/#{plist_path}")["GOOGLE_APP_ID"]
-        UI.shell_error!("can't extract GOOGLE_APP_ID") if identifier.empty?
+
+        if(archive_path)
+          app_path = parse_plist("#{archive_path}/Info.plist")["ApplicationProperties"]["ApplicationPath"]
+          UI.shell_error!("can't extract application path from Info.plist at #{archive_path}") if app_path.empty?
+          identifier = parse_plist("#{archive_path}/Products/#{app_path}/#{plist_path}")["GOOGLE_APP_ID"]
+          UI.shell_error!("can't extract GOOGLE_APP_ID") if identifier.empty?
+        else
+          identifier = parse_plist("./ios/#{plist_path}")
+          UI.shell_error!("Attempted to read plist at ./ios, can't extract GOOGLE_APP_ID") if identifier.empty?
+        end
         return identifier
       end
 


### PR DESCRIPTION
Use plist_path directly if archive_path is null, which will be the case if the action is used from a different lane as gym()